### PR TITLE
Let supported version names in HTML match expected values

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -18,10 +18,10 @@
         <p>
             Which version of Minecraft was this map created by?
             <br>
-            <input type="radio" id="version_1.8.1" name="version" value="1.8.1" checked>
+            <input type="radio" id="version_1.8.1" name="version" value="1.8.1+" checked>
             <label for="version_1.8.1">1.8.1 or later</label>
             <br>
-            <input type="radio" id="version_1.8.0" name="version" value="1.8.0">
+            <input type="radio" id="version_1.8.0" name="version" value="1.8.0-">
             <label for="version_1.8.0">1.8.0 or earlier</label>
         </p>
         <p>


### PR DESCRIPTION
While trying to run the web interface, I discovered that the `version` values submitted in the form didn't match what the script needed. This rectifies the problem :smile_cat: 