### PR TITLE
Run in a docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3
+
+WORKDIR /usr/src/app
+
+RUN pip install --no-cache-dir NBT Pillow
+
+COPY . .
+
+CMD [ "python", "-m", "http.server", "--cgi", "8000" ]

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A command-line utility, web application, and Python library to convert Minecraft
     ```
 
 ## Usage
-There are three ways to use this tool:
+There are four ways to use this tool:
 
 1.  Run `mcmapimg.py` as a command-line program. See the output of:
     ```
@@ -39,4 +39,22 @@ There are three ways to use this tool:
     python
     >>> import mcmapimg
     >>> help(mcmapimg)
+    ```
+
+4.  In a docker container. First build the image and run the container:
+    ```shell
+    docker build -t mcmapimg .
+    docker run -it --rm -p 8000:8000 mcmapimg
+    ```
+    Then access the webpage:
+    ```
+    http://localhost:8000
+    ```
+
+    The docker image also supports running from the command line:
+    ```shell
+    cd directory/with/map_files.dat
+
+    docker run -it --rm -v "$PWD":/usr/src/app/maps \
+        mcmapimg ./mcmapimg.py maps/[in_map_file.dat] maps/[out_img_file.png]
     ```

--- a/README.md
+++ b/README.md
@@ -41,20 +41,26 @@ There are four ways to use this tool:
     >>> help(mcmapimg)
     ```
 
-4.  In a docker container. First build the image and run the container:
-    ```shell
+4.  In a docker container. First build the image:
+    ```
     docker build -t mcmapimg .
+    ```
+
+    Then run the container:
+    ```
     docker run -it --rm -p 8000:8000 mcmapimg
     ```
-    Then access the webpage:
+
+    Finally access the webpage:
     ```
     http://localhost:8000
     ```
 
     The docker image also supports running from the command line:
-    ```shell
-    cd directory/with/map_files.dat
-
+    ```
+    cd directory/with/map_dat_files/
+    ```
+    ```
     docker run -it --rm -v "$PWD":/usr/src/app/maps \
         mcmapimg ./mcmapimg.py maps/[in_map_file.dat] maps/[out_img_file.png]
     ```


### PR DESCRIPTION
This pull requires pulls #1 #2 and #3 in order to work.

By default the container runs the web interface, but it also supports the command line options.

First build the image:
```
docker build -t mcmapimg .
```

Then run the container:
```
docker run -it --rm -p 8000:8000 mcmapimg
```

Finally access the webpage:
```
http://localhost:8000
```

Running from the command line:
```
cd directory/with/map_dat_files
```
```
docker run -it --rm -v "$PWD":/usr/src/app/maps \
    mcmapimg ./mcmapimg.py maps/[in_map_file.dat] maps/[out_img_file.png]
```